### PR TITLE
Save base layer with map configurations.

### DIFF
--- a/js/mapfilter/appview.js
+++ b/js/mapfilter/appview.js
@@ -42,7 +42,8 @@ module.exports = Backbone.View.extend({
       bingKey: options.bingKey,
       collection: this.collection,
       appView: this,
-      interactive: true
+      interactive: true,
+      onBaseLayerChange: this.setCurrentBaseLayer
     })
 
     this.printPane = new PrintPane({
@@ -117,5 +118,9 @@ module.exports = Backbone.View.extend({
 
   saveFilters: function() {
     this.saveFilterPane.show({model: this.filterPane.save()});
+  },
+
+  setCurrentBaseLayer: function(evt) {
+    window.currentBaseLayer = evt.name
   }
 })

--- a/js/mapfilter/filter_pane/filter_pane.js
+++ b/js/mapfilter/filter_pane/filter_pane.js
@@ -115,24 +115,30 @@ module.exports = require('backbone').View.extend({
   },
 
   parseDateValue: function(data) {
-    if (data === undefined || data == null)
-      return null;
+    if (data) {
+      const format = window.locale.d3().timeFormat('%d %b %Y');
+      var locales = Object.getOwnPropertyNames(window.locale_d3);
+      var defaultLocale = window.locale.current();
+      locales.splice(locales.indexOf(defaultLocale), 1)
+      locales.unshift(defaultLocale)
 
-    const format = window.locale.d3().timeFormat('%d %b %Y');
-    const locales = Object.getOwnPropertyNames(window.locale_d3);
-    var startDateObj = null, endDateObj = null;
+      var startDateObj = null, endDateObj = null;
 
-    for (var index in locales) {
-      if (startDateObj == null) {
-        var locale = locales[index];
-        startDateObj = window.locale_d3[locale].timeFormat('%d %b %Y').parse(data.startDate);
-        if (startDateObj)
-          endDateObj = window.locale_d3[locale].timeFormat('%d %b %Y').parse(data.endDate);
+      for (var index in locales) {
+        if (startDateObj == null || endDateObj == null) {
+          var locale = locales[index];
+          startDateObj = window.locale_d3[locale].timeFormat('%d %b %Y').parse(data.startDate);
+          if (startDateObj)
+            endDateObj = window.locale_d3[locale].timeFormat('%d %b %Y').parse(data.endDate);
+        }
       }
-    }
-
-    var startDate = format(startDateObj), endDate = format(endDateObj);
-    return { startDate: startDate, endDate: endDate }
+      if (startDateObj && endDateObj) {
+        var startDate = format(startDateObj), endDate = format(endDateObj);
+        return { startDate: startDate, endDate: endDate }
+      } else
+        return null
+    } else
+      return null;
   },
 
   // hide elements

--- a/js/mapfilter/filter_pane/save_filter_pane.js
+++ b/js/mapfilter/filter_pane/save_filter_pane.js
@@ -74,6 +74,8 @@ module.exports = require('backbone').View.extend({
         value: this.model,
         zoom: this.config.get('mapZoom')
       } //TODO: lat/long/uri/anything else
+      if (window.currentBaseLayer)
+        model_data['baseLayer'] = window.currentBaseLayer;
       this.community_filters.url = path;
       this.community_filters.create(model_data, request_options);
     }


### PR DESCRIPTION
Send along the base layer that is currently selected when
saving maps, such that they can be restored when loaded.

Currently, this feature is language-specific; well want to
assign IDs or something to layers going forward if we want
filters to be compatible across languages.
