### PR TITLE
Update print pane map with main map changes.

### DIFF
--- a/js/mapfilter/appview.js
+++ b/js/mapfilter/appview.js
@@ -43,7 +43,7 @@ module.exports = Backbone.View.extend({
       collection: this.collection,
       appView: this,
       interactive: true,
-      onBaseLayerChange: this.setCurrentBaseLayer
+      onBaseLayerChange: this.setCurrentBaseLayer.bind(this)
     })
 
     this.printPane = new PrintPane({
@@ -122,5 +122,7 @@ module.exports = Backbone.View.extend({
 
   setCurrentBaseLayer: function(evt) {
     window.currentBaseLayer = evt.name
+    this.printPane.mapPane.setBaseLayer(evt.name)
   }
+
 })

--- a/js/mapfilter/map_pane/map_pane.js
+++ b/js/mapfilter/map_pane/map_pane.js
@@ -218,14 +218,19 @@ module.exports = require('backbone').View.extend({
     if (self.config) {
       var defaultBaseLayer = self.config.get('baseLayer')
       if (defaultBaseLayer && self.currentBaseLayer != defaultBaseLayer && name == defaultBaseLayer) {
-        var oldLayer = self.baseMaps[self.currentBaseLayer]
-        var newLayer = self.baseMaps[name]
-        if (oldLayer && newLayer) {
-          self.map.removeLayer(oldLayer);
-          self.map.addLayer(newLayer);
-          self.currentBaseLayer = name;
-        }
+        self.setBaseLayer(name)
       }
+    }
+  },
+
+  setBaseLayer: function(name, that) {
+    var self = that || this
+    var oldLayer = self.baseMaps[self.currentBaseLayer]
+    var newLayer = self.baseMaps[name]
+    if (oldLayer && newLayer) {
+      self.map.removeLayer(oldLayer);
+      self.map.addLayer(newLayer);
+      self.currentBaseLayer = name;
     }
   }
 


### PR DESCRIPTION
When the base layer for the main map changes, update the
base layer for the print pane as well to keep them in sync.
The print pane does not talk back to the main map.
