### PR TITLE
Protect against edge case for loading filters.

### DIFF
--- a/js/mapfilter/filter_pane/filter_pane.js
+++ b/js/mapfilter/filter_pane/filter_pane.js
@@ -115,7 +115,7 @@ module.exports = require('backbone').View.extend({
   },
 
   parseDateValue: function(data) {
-    if (data) {
+    if (data && data.startDate && data.endDate) {
       const format = window.locale.d3().timeFormat('%d %b %Y');
       var locales = Object.getOwnPropertyNames(window.locale_d3);
       var defaultLocale = window.locale.current();


### PR DESCRIPTION
Continuous filters can be null when initially loaded (without
submission data). Explicitly check for date values, not just
the presence of the object itself.
