### PR TITLE
Lock locations for saved maps by UUID.

### DIFF
--- a/js/mapfilter/filter_pane/save_filter_pane.js
+++ b/js/mapfilter/filter_pane/save_filter_pane.js
@@ -77,12 +77,16 @@ module.exports = require('backbone').View.extend({
           alert(t('error.' + error_key));
         }
       }
+
       var model_data = {
         name: name,
         value: this.model,
         zoom: parseInt(this.$("#filter-zoom").html()),
         latitude: parseFloat(this.$("#filter-latitude").html()),
-        longitude: parseFloat(this.$("#filter-longitude").html())
+        longitude: parseFloat(this.$("#filter-longitude").html()),
+        locations: this.mapPane.getPoints(function(value) {
+          return value.getIdentifier();
+        })
       } //TODO: lat/long/uri/anything else
       if (window.currentBaseLayer)
         model_data['baseLayer'] = window.currentBaseLayer;

--- a/js/mapfilter/map_pane/map_pane.js
+++ b/js/mapfilter/map_pane/map_pane.js
@@ -250,6 +250,20 @@ module.exports = require('backbone').View.extend({
 
   getMap: function() {
     return this.map;
+  },
+
+  getPoints: function(cb) {
+    var markers = [];
+    var source = this.markersById;
+    this.collection.groupByCid.all().forEach(function (d) {
+      if (d.value == 1 && source[d.key]) {
+        if (cb)
+          markers.push(cb(source[d.key]));
+        else
+          markers.push(source[d.key].getLocation());
+      }
+    });
+    return markers;
   }
 
 })

--- a/js/mapfilter/map_pane/marker_view.js
+++ b/js/mapfilter/map_pane/marker_view.js
@@ -38,16 +38,11 @@ module.exports = require('backbone').View.extend({
     }
 
     this._interactive = options.interactive
-    var loc = this.model.coordinates()
-
-    // Sometimes models (monitoring reports) do not have coordinates
-    if (!loc) loc = [0, 0]
-    if (!loc[0] || !loc[1]) loc = [0, 0]
 
     this.appView = options.appView
 
     // Create a new marker with the default icon and add to the map
-    this.marker = L.marker(loc, {
+    this.marker = L.marker(this.getLocation(), {
       icon: this.icon
     }).addTo(options.map)
 
@@ -70,6 +65,20 @@ module.exports = require('backbone').View.extend({
     // Reference the marker's current z-index (we change the z-index later
     // when the markers are filtered, so unfiltered markers appear on top)
     this._lastZIndex = this.marker.options.zIndexOffset
+  },
+
+  getLocation: function() {
+    var loc = this.model.coordinates();
+
+    // Sometimes models (monitoring reports) do not have coordinates
+    if (!loc) loc = [0, 0]
+    if (!loc[0] || !loc[1]) loc = [0, 0]
+
+    return loc;
+  },
+
+  getIdentifier: function() {
+    return this.model.get('meta')['instanceId'];
   },
 
   // TODO: remove/update this


### PR DESCRIPTION
When saving a map, save the UUID's of the submissions that
are displayed as well, such that these (and only these) can
be displayed when the map is loaded.
