### PR TITLE
Fix show all/select all translations for filters.

### DIFF
--- a/data/en.json
+++ b/data/en.json
@@ -37,8 +37,9 @@
     },
     "ui": {
         "filter_view": {
+            "show_all": "Show All",
             "select_one": "only",
-            "select_all": "Show All",
+            "select_all": "Select All",
             "select_dates": "Select Dates",
             "dates": "Dates",
             "print_report": "Print Report",

--- a/data/es.json
+++ b/data/es.json
@@ -37,8 +37,9 @@
     },
     "ui": {
         "filter_view": {
+            "show_all": "Mostrar Todo",
             "select_one": "uno",
-            "select_all": "Mostrar Todo",
+            "select_all": "Seleccionar Todos",
             "select_dates": "Seleccionar Fechas",
             "dates": "Fechas",
             "print_report": "Imprimir informe",

--- a/templates/continuous-filter.tpl
+++ b/templates/continuous-filter.tpl
@@ -1,4 +1,4 @@
-<h4><%= t("ui.filter_view.dates") %> &nbsp;<small><a href="#" class="select select_all"><%= t("ui.filter_view.select_all") %></a></small></h4>
+<h4><%= t("ui.filter_view.dates") %> &nbsp;<small><a href="#" class="select select_all"><%= t("ui.filter_view.show_all") %></a></small></h4>
 <div class="filter_range" data-start="<%= startDate %>" data-end="<%= endDate %>">
 <%= filterRange %>
 <br><small><a href="#" class="select select_range"><%= t("ui.filter_view.select_dates") %></a></small>

--- a/templates/discrete-filter.tpl
+++ b/templates/discrete-filter.tpl
@@ -1,4 +1,4 @@
-<h4><%= title %> &nbsp;<small><a href="#" class="select select_all"><%= t("ui.select_all")%></a></small></h4>
+<h4><%= title %> &nbsp;<small><a href="#" class="select select_all"><%= t("ui.filter_view.select_all")%></a></small></h4>
 <div>
   <% checkboxes.forEach(function(checkbox) { %>
     <%= checkbox %>


### PR DESCRIPTION
Discrete filters were looking for a missing translation,
and the text for select all was for show all, which is a
slightly different concept.

Changed the select for select all and added a new show all
translation.
