### PR TITLE
Additional details shown when saving maps.

### DIFF
--- a/data/en.json
+++ b/data/en.json
@@ -89,7 +89,10 @@
     },
     "message": {
         "nodata": "<em class=\"blank\">Not Reported</em>",
-        "filter_saved": "Configuration saved"
+        "filter_saved": "Configuration saved",
+        "filter_updated": "Configuration updated",
+        "data_last_saved": "Data last saved on",
+        "data_not_saved": "No monitoring data has been uploaded to Community Lands yet"
     },
     "error": {
         "filter_missing": "Filter missing.",

--- a/data/es.json
+++ b/data/es.json
@@ -89,7 +89,10 @@
     },
     "message": {
         "nodata": "<em class=\"blank\">No Reportado</em>",
-        "filter_saved": "Configuración guardada"
+        "filter_saved": "Configuración guardada",
+        "filter_updated": "Configuración actualizada",
+        "data_last_saved": "Datos guardados en",
+        "data_not_saved": "Datos del monitoreo aun no han sido subido a Community Lands"
     },
     "error": {
         "filter_missing": "Sin filtro.",

--- a/js/mapfilter/filter_pane/save_filter_pane.js
+++ b/js/mapfilter/filter_pane/save_filter_pane.js
@@ -64,7 +64,22 @@ module.exports = require('backbone').View.extend({
         success: function(m, r, o) {
           if (r && r.error)
             alert(t('error.' + (r.code || 'unknown')));
-          else
+          else if (r && r.entity) {
+            var message = '';
+            var status = r.entity;
+            if (status.update)
+              message += t('message.filter_updated')
+            else
+              message += t('message.filter_saved')
+
+            if (status.data_version) {
+              var fmt = window.locale.d3().timeFormat("%a %b %e %X %Y")
+              message += ' (' + t('message.data_last_saved') + ' ' + fmt(new Date(status.data_version)) + ').';
+            } else
+              message += ' (' + t('message.data_not_saved') + ').';
+
+            alert(message);
+          } else
             alert(t('message.filter_saved'))
         },
         error: function(m, err, o) {


### PR DESCRIPTION
When saving maps to community lands, and entity is returned
that yields additional information that can be displayed to
users, such as whether or not the operation was a new save
or an update, and the timestamp of the last data update for
that community.

Use this information to display when the last update was; if
no data exists, convey that to the user as well.
